### PR TITLE
Add "tutor openstack" sub-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,26 @@ should all use different flavors of your custom images, then you must
 apply a naming or tagging convention to tell your images apart.
 
 
+## Configuration
+
+This plugin uses configuration information from two sources:
+
+* the `OS_*` environment variables you use to connect to your
+  OpenStack API,
+* Tutor’s own `config.yml` configuration.
+
+
+### OpenStack environment variables
+
+This plugin will read your OpenStack credentials and
+project/domain/region configuration from the environment, like any
+other OpenStack application would. That means that you can either set
+`OS_CLOUD` to select a configuration [from a `clouds.yaml`
+file](https://docs.openstack.org/python-openstackclient/latest/cli/man/openstack.html#config-files),
+or define a set of individual [`OS_*` environment
+variables](https://docs.openstack.org/python-openstackclient/latest/cli/man/openstack.html#environment-variables).
+
+
 ### Required `config.yml` settings
 
 *If you plan to invoke `tutor openstack create-template`,* you must

--- a/README.md
+++ b/README.md
@@ -1,12 +1,154 @@
 # openstack plugin for [Tutor](https://docs.tutor.overhang.io)
 
+This plugin adds a `tutor openstack` command group to Tutor, which you
+can use to create a Kubernetes cluster with [OpenStack
+Magnum](https://docs.openstack.org/magnum/latest/user/), running on a
+private or public OpenStack cloud.
+
+You can do so by spinning up a cluster based on a *template* that your
+cloud service provider has created for you, or — provided you have the
+credentials that allow you to do that — you can create a template
+yourself, and then spin up your cluster from that template.
+
+That cluster can then serve as an environment for you to deploy Tutor
+with the `tutor k8s` command group.
+
+
 ## Installation
 
-    pip install git+https://github.com/hastexo/tutor-contrib-openstack
+```
+pip install tutor-contrib-openstack
+```
+
+... or install from this repository, using `git+https`.
+
 
 ## Usage
 
-    tutor plugins enable openstack
+Once installed, you enable this plugin with:
+
+```
+tutor plugins enable openstack
+```
+
+### Creating a cluster
+
+Once properly configured (see below), you can spin up a Kubernetes
+cluster with
+
+```
+tutor openstack create-cluster
+```
+
+... or you can first create a template and *then* spin up a cluster:
+
+```
+tutor openstack create-template
+tutor openstack create-cluster
+```
+
+Either command also supports a `--dry-run` option, where instead of
+actually invoking OpenStack cloud API calls, you only see what *would*
+be done.
+
+
+### Deleting a cluster
+
+If you want to delete your cluster, you may do so with this command:
+
+```
+tutor openstack delete-cluster
+```
+
+This command will prompt you before proceeding with cluster deletion.
+
+**Caution:** deleting your Kubernetes cluster is irreversible and will
+delete *all* Tutor deployments in all Kubernetes namespaces. Proceed
+at your own risk.
+
+
+### Required `config.yml` settings
+
+*If you plan to invoke `tutor openstack create-template`,* you must
+add the following configuration values to your Tutor `config.yml`. The
+plugin cannot provide reasonable defaults for them, as they are bound
+to differ between OpenStack installations:
+
+* `OPENSTACK_IMAGE`: The base image UUID to use for your Kubernetes
+  cluster nodes. This should be a Fedora CoreOS image, and it **must**
+  have its `os_distro` property set to `fedora-coreos`, otherwise
+  OpenStack Magnum will refuse to use it. You can also use an image
+  name, if it uniquely identifies a single image.
+* `OPENSTACK_EXTERNAL_NETWORK`: A network marked `external` that your
+  OpenStack environment uses to connect to the outside world, and from
+  where your cluster can get floating IPv4 addresses.
+* `OPENSTACK_MASTER_FLAVOR`: The flavor to use for your control plane
+  (“master”) nodes.
+* `OPENSTACK_NODE_FLAVOR`: The flavor to use for your worker
+  (“minion”) nodes.
+
+*If you only want to run `tutor openstack create-cluster`,* and rely on
+a pre-existing template, then you should also set:
+
+* `OPENSTACK_TEMPLATE`: The name of the OpenStack Magnum cluster
+  template to use. You can reference it by UUID or name. The default
+  assumes that the template is uniquely named `tutor-kubernetes`.
+
+
+### Optional `config.yml` settings
+
+All other supported configuration variables are optional to set. These
+are the variables that can be set for each *cluster,* and will apply
+to any invocation of the `tutor openstack create-cluster` command.
+
+* `OPENSTACK_CLUSTER_NAME`: The name of your Kubernetes cluster
+  (default `tutor`).
+* `OPENSTACK_KEYPAIR`: The name of an OpenStack SSH keypair you want
+  to deploy to your Kubernetes nodes, if you want to be able to SSH
+  into them. This is optional; by default no SSH key will be deployed
+  and you will only be able to interact with the Kubernetes containers
+  with `kubectl exec -it`, if needed.
+* `OPENSTACK_MASTER_COUNT`: The number of load-balanced control plane
+  (“master”) nodes in your cluster. The default is `1`; for a highly
+  available control plane set this to `3`.
+* `OPENSTACK_NODE_COUNT`: The number or worker (“minion”) nodes in
+  your cluster. The default is `1`; for a production Tutor environment
+  you may want to set this to at least `2` for some protection against
+  node failure. If you want to run multiple Tutor environments on a
+  single cluster in separate Kubernetes namespaces, you might want to
+  add more nodes.
+
+Other variables can only be set for a *cluster template,* and will
+thus apply only if you run `tutor openstack create-template`:
+
+* `OPENSTACK_KUBERNETES_VERSION`: The Kubernetes version to deploy. If
+  unset, this will configure the template to deploy whatever
+  Kubernetes release is the default for your version of OpenStack
+  Magnum.
+* `OPENSTACK_DOCKER_VOLUME_SIZE`: The size of the Docker volume
+  configured for your control plane and worker nodes, in GiB. The
+  default is `50`.
+* `OPENSTACK_FIXED_NETWORK`: A pre-existing OpenStack Neutron network
+  to patch your nodes into. The default is to create a new network for
+  the cluster.
+* `OPENSTACK_FIXED_SUBNET`: A pre-existing OpenStack Neutron subnet to
+  patch your nodes into. The default is to create a new subnet for the
+  cluster.
+* `OPENSTACK_NETWORK_DRIVER`: The network driver to use for your
+  Kubernetes cluster. If unset, this will use whatever the default
+  network driver is for your OpenStack Magnum installation (usually
+  `flannel`). You can alternatively set this to `calico`.
+* `OPENSTACK_HYPERKUBE_PREFIX`: The prefix to use for the `hyperkube`
+  image. This is required to set for deploying any Kubernetes release
+  from 1.19.0 forward. There is no default, but you might want to set
+  `docker.io/catalystcloud/`.
+* `OPENSTACK_ENABLE_REGISTRY`: Configure your Kubernetes cluster to
+  use a private, stateless registry that is backed by OpenStack Swift
+  (or any other service exposing the Swift API). Default `false`; if
+  you set this to `true` be sure to check with your OpenStack service
+  provider if they have configured their Magnum service to support
+  this.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,40 @@ delete *all* Tutor deployments in all Kubernetes namespaces. Proceed
 at your own risk.
 
 
+### Running your own registry
+
+OpenStack Magnum has a feature in which it exposes a private registry,
+backed by OpenStack Swift, on all worker nodes. You can use this
+feature with Tutor, to expose your custom-built images to your
+Kubernetes cluster.
+
+To do so, you will have to
+
+1. set `OPENSTACK_ENABLE_REGISTRY` to `true` *before* you run `tutor
+   openstack create-template` and `tutor openstack create-cluster`.
+
+2. run `tutor openstack registry` to run a local copy of the registry,
+   which is backed by the same Swift object store as that in your
+   Kubernetes cluster. To be clear, that means that your locally
+   available registry and that in your production cluster *are
+   functionally identical,* since they are backed by the same storage.
+
+3. set your Tutor image references to include the `localhost:5000`
+   registry.
+
+4. run `tutor images build` and `tutor images push` to create and
+   register your images, as you [you normally
+   would](https://docs.tutor.overhang.io/configuration.html#custom-open-edx-docker-image)
+   with any other custom Tutor images or specific registry.
+
+Please note: when used in this manner, the images in your registry
+become available to your entire Kubernetes cluster, not just to a
+single namespace. If you are planning to run multiple Tutor
+configurations on one cluster, each using its own namespace, and they
+should all use different flavors of your custom images, then you must
+apply a naming or tagging convention to tell your images apart.
+
+
 ### Required `config.yml` settings
 
 *If you plan to invoke `tutor openstack create-template`,* you must
@@ -147,7 +181,7 @@ thus apply only if you run `tutor openstack create-template`:
   (or any other service exposing the Swift API). Default `false`; if
   you set this to `true` be sure to check with your OpenStack service
   provider if they have configured their Magnum service to support
-  this.
+  this. 
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # openstack plugin for [Tutor](https://docs.tutor.overhang.io)
 
-This plugin adds a `tutor openstack` command group to Tutor, which you
-can use to create a Kubernetes cluster with [OpenStack
-Magnum](https://docs.openstack.org/magnum/latest/user/), running on a
-private or public OpenStack cloud.
+This **experimental** plugin adds a `tutor openstack` command group to
+Tutor, which you can use to create a Kubernetes cluster with
+[OpenStack Magnum](https://docs.openstack.org/magnum/latest/user/),
+running on a private or public OpenStack cloud.
 
 You can do so by spinning up a cluster based on a *template* that your
 cloud service provider has created for you, or — provided you have the

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,10 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.6",
-    install_requires=["tutor"],
+    install_requires=[
+        "tutor",
+        "openstacksdk",
+    ],
     entry_points={
         "tutor.plugin.v0": [
             "openstack = tutoropenstack.plugin"

--- a/tutoropenstack/command.py
+++ b/tutoropenstack/command.py
@@ -3,6 +3,7 @@
 This defines the "openstack" command group and its subcommands:
 
 * create-cluster
+* create-template
 """
 import click
 
@@ -29,6 +30,15 @@ def get_openstack_connection():
     # with OS_CLOUD. It has nothing to do with the tutor.config
     # dictionary.
     return connection.from_config()
+
+
+def check_required_options(config, options):
+    """Raise a Click error if a required config.yml option is unset."""
+    for option in options:
+        if not config.get(option):
+            raise click.UsageError(
+                f"You must set {option} to a non-empty value."
+            )
 
 
 def create_coe_cluster_kwargs(config):
@@ -70,4 +80,90 @@ def create_cluster(context, dry_run):
         conn = get_openstack_connection()
         cluster = conn.create_coe_cluster(**kwargs)
         fmt.echo_info("Cluster launch returned:\n%s" %
+                      pformat(cluster))
+
+
+def create_coe_cluster_template_kwargs(config):
+    """Construct arguments for the create_coe_cluster_template command."""
+    kubernetes_version = config['OPENSTACK_KUBERNETES_VERSION']
+    name = config['OPENSTACK_TEMPLATE']
+    docker_volume_size = config['OPENSTACK_DOCKER_VOLUME_SIZE']
+    external_network = config['OPENSTACK_EXTERNAL_NETWORK']
+    master_flavor = config['OPENSTACK_MASTER_FLAVOR']
+    node_flavor = config['OPENSTACK_NODE_FLAVOR']
+    network_driver = config['OPENSTACK_NETWORK_DRIVER']
+    fixed_network = config['OPENSTACK_FIXED_NETWORK']
+    fixed_subnet = config['OPENSTACK_FIXED_SUBNET']
+    image = config['OPENSTACK_IMAGE']
+    hyperkube_prefix = config['OPENSTACK_HYPERKUBE_PREFIX']
+    enable_registry = config['OPENSTACK_ENABLE_REGISTRY']
+
+    labels = {
+        'container_runtime': 'containerd',
+        'cinder_csi_enabled': True,
+        'cloud_provider_enabled': True,
+        'metrics_server_enabled': False,
+    }
+    if kubernetes_version:
+        labels['kube_tag'] = f'v{kubernetes_version}'
+    if hyperkube_prefix:
+        labels['hyperkube_prefix'] = hyperkube_prefix
+
+    kwargs = {
+        'name': name,
+        'coe': 'kubernetes',
+        'docker_storage_driver': 'overlay2',
+        'docker_volume_size': docker_volume_size,
+        'external_network_id': external_network,
+        'flavor_id': node_flavor,
+        'floating_ip_enabled': True,
+        'image_id': image,
+        'labels': labels,
+        'master_flavor_id': master_flavor,
+        'master_lb_enabled': True,
+        'volume_driver': 'cinder'
+    }
+    if network_driver:
+        kwargs['network_driver'] = network_driver
+    if fixed_network:
+        kwargs['fixed_network'] = fixed_network
+    if fixed_subnet:
+        kwargs['fixed_subnet'] = fixed_subnet
+    if enable_registry:
+        kwargs['registry_enabled'] = True
+        kwargs['insecure_registry'] = 'localhost:5000'
+    return kwargs
+
+
+@openstack.command(help="Create a Kubernetes cluster template on OpenStack")
+@click.option('--dry-run', is_flag=True, default=False,
+              help="Don't actually interact with OpenStack, "
+                   "just show what would be done.")
+@click.pass_obj
+def create_template(context, dry_run):
+    """Create a Magnum cluster template based on Tutor settings."""
+    config = tutor_config.load(context.root)
+
+    # We can't provide sensible defaults for these, as they will be
+    # differently named in every OpenStack cloud. So, just require
+    # that they are set in the configuration.
+    check_required_options(
+        config,
+        ['OPENSTACK_EXTERNAL_NETWORK',
+         'OPENSTACK_MASTER_FLAVOR',
+         'OPENSTACK_NODE_FLAVOR',
+         'OPENSTACK_IMAGE',
+        ]
+    )
+
+    kwargs = create_coe_cluster_template_kwargs(config)
+    fmt.echo_info(
+        "Creating cluster template with options:\n%s" % pformat(kwargs)
+    )
+    if dry_run:
+        fmt.echo_info("Dry run, not invoking API call")
+    else:
+        conn = get_openstack_connection()
+        cluster = conn.create_coe_cluster_template(**kwargs)
+        fmt.echo_info("Cluster template creation returned:\n%s" %
                       pformat(cluster))

--- a/tutoropenstack/command.py
+++ b/tutoropenstack/command.py
@@ -1,0 +1,73 @@
+"""tutor openstack: Implements a Click command group for openstack commands.
+
+This defines the "openstack" command group and its subcommands:
+
+* create-cluster
+"""
+import click
+
+from tutor import config as tutor_config
+from tutor import fmt
+
+from openstack import connection
+from pprint import pformat
+
+
+@click.group(name="openstack",
+             help="Manage a Kubernetes cluster on OpenStack")
+@click.pass_obj
+def openstack(context):
+    """Define the "openstack" command group."""
+    pass
+
+
+def get_openstack_connection():
+    """Fetch an OpenStack connection using standard configuration sources."""
+    # from_config just happens to be the name of the method in the
+    # OpenStack SDK that initializes the connection based on OS_*
+    # environment variables, or a configuration file in combination
+    # with OS_CLOUD. It has nothing to do with the tutor.config
+    # dictionary.
+    return connection.from_config()
+
+
+def create_coe_cluster_kwargs(config):
+    """Construct arguments for the create_coe_cluster command."""
+    name = config['OPENSTACK_CLUSTER_NAME']
+    cluster_template = config['OPENSTACK_TEMPLATE']
+    keypair = config['OPENSTACK_KEYPAIR']
+    master_count = config['OPENSTACK_MASTER_COUNT']
+    node_count = config['OPENSTACK_NODE_COUNT']
+    timeout = 60
+
+    kwargs = {
+        'name': name,
+        'cluster_template_id': cluster_template,
+        'master_count': master_count,
+        'node_count': node_count,
+        'create_timeout': timeout,
+    }
+    if keypair:
+        kwargs['keypair'] = keypair
+    return kwargs
+
+
+@openstack.command(help="Create a Kubernetes cluster on OpenStack")
+@click.option('--dry-run', is_flag=True, default=False,
+              help="Don't actually interact with OpenStack, "
+                   "just show what would be done.")
+@click.pass_obj
+def create_cluster(context, dry_run):
+    """Create a Magnum cluster based on Tutor settings."""
+    config = tutor_config.load(context.root)
+    kwargs = create_coe_cluster_kwargs(config)
+    fmt.echo_info(
+        "Launching cluster with options:\n%s" % pformat(kwargs)
+    )
+    if dry_run:
+        fmt.echo_info("Dry run, not invoking API call")
+    else:
+        conn = get_openstack_connection()
+        cluster = conn.create_coe_cluster(**kwargs)
+        fmt.echo_info("Cluster launch returned:\n%s" %
+                      pformat(cluster))

--- a/tutoropenstack/plugin.py
+++ b/tutoropenstack/plugin.py
@@ -19,6 +19,13 @@ config = {
         'KEYPAIR': None,
         'MASTER_COUNT': 1,
         'NODE_COUNT': 1,
+        'KUBERNETES_VERSION': None,
+        'DOCKER_VOLUME_SIZE': 50,
+        'FIXED_NETWORK': None,
+        'FIXED_SUBNET': None,
+        'NETWORK_DRIVER': None,
+        'HYPERKUBE_PREFIX': None,
+        'ENABLE_REGISTRY': False,
     },
 }
 

--- a/tutoropenstack/plugin.py
+++ b/tutoropenstack/plugin.py
@@ -1,6 +1,8 @@
 """Plugin definition for the Tutor openstack plugin."""
 
 from glob import glob
+from .command import openstack as openstack_command
+
 import os
 import pkg_resources
 
@@ -9,9 +11,22 @@ templates = pkg_resources.resource_filename(
     "tutoropenstack", "templates"
 )
 
-config = {}
+
+config = {
+    "defaults": {
+        'CLUSTER_NAME': 'tutor',
+        'TEMPLATE': 'tutor-kubernetes',
+        'KEYPAIR': None,
+        'MASTER_COUNT': 1,
+        'NODE_COUNT': 1,
+    },
+}
+
 
 hooks = {}
+
+
+command = openstack_command
 
 
 def patches():


### PR DESCRIPTION
Apologies in advance; this is a rather big review.

This adds the ability to create an Magnum cluster template and cluster, based on Tutor configuration settings. Thus, it tightly integrates an OpenStack managed Kubernetes cluster with Tutor.

In addition, it adds a facility to run a local registry which is backed by the same Swift configuration as that on the Magnum cluster. Thus, when started with `tutor openstack registry` with appropriate OpenStack credentials, we'll be able to run `tutor images push` against the local registry, and thereby make the images available to all namespaces in the Kubernetes cluster as well.

You probably want to review this commit by commit, rather than looking into the whole changeset straight away.

Also, I am aware that `command.py` has become rather large at this point and should be split up into multiple modules. I'll leave that refactoring for after these patches have landed.