### PR TITLE
Prepare the 0.1.0 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -7,3 +7,5 @@ current_version = 0.0.0
 [bumpversion:file:CHANGELOG.md]
 search = Unreleased
 replace = Version {new_version} ({now:%Y-%m-%d})
+
+[bumpversion:file:README.md]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 commit = True
 tag = True
 message = build: Version {new_version}
-current_version = 0.0.0
+current_version = 0.1.0
 
 [bumpversion:file:CHANGELOG.md]
 search = Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,4 @@
 
 **Experimental. Do not use in production.**
 
-* Created plugin with
-  [Cookiecutter](https://cookiecutter.readthedocs.io/) 
-  from gh:fghaas/cookiecutter-tutor-plugin.
+* Initial experimental release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## Version 0.1.0 (2022-02-22)
 
 **Experimental. Do not use in production.**
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@ with the `tutor k8s` command group.
 ## Installation
 
 ```
-pip install tutor-contrib-openstack
+pip install git+https://github.com/hastexo/tutor-contrib-openstack@v0.0.0
 ```
-
-... or install from this repository, using `git+https`.
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ with the `tutor k8s` command group.
 ## Installation
 
 ```
-pip install git+https://github.com/hastexo/tutor-contrib-openstack@v0.0.0
+pip install git+https://github.com/hastexo/tutor-contrib-openstack@v0.1.0
 ```
 
 


### PR DESCRIPTION
Now that we have a certain amount of baseline functionality, prepare tagging a 0.1.0 release.