### PR TITLE
fix: Add a check to wait for registry to start up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* fix: Add a check to wait for the registry to start up before continuing.
+
 ## Version 0.1.1 (2022-03-22)
 
 * fix: Add missing whitespace in warning message for `tutor openstack


### PR DESCRIPTION
Add a check with a retry mechanism to wait for the registry to
start up before continuing.

Resolves #5