### PR TITLE
fix: Limit the plugin to Open edX Maple release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     include_package_data=True,
     python_requires=">=3.6",
     install_requires=[
-        "tutor",
+        "tutor<14",
         "openstacksdk",
     ],
     setup_requires=['setuptools-scm'],


### PR DESCRIPTION
From version 14, Tutor uses the Open edX Nutmeg release. Until we add
support for that release, limit the plugin to Tutor versions <14.

After this PR is merged, we will create a branch called `maple`. The work to
update the plugin to Nutmeg and Tutor v1 plugin API will continue in
the `main` branch.