### PR TITLE
refactor: Use Tutor v1 plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* refactor: Use Tutor v1 plugin API.
+
 ## Version 0.1.2 (2022-04-27)
 
 * fix: Add a check to wait for the registry to start up before continuing.

--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,12 @@ setup(
     include_package_data=True,
     python_requires=">=3.6",
     install_requires=[
-        "tutor<14",
+        "tutor <14, >=13.2.0",
         "openstacksdk",
     ],
     setup_requires=['setuptools-scm'],
     entry_points={
-        "tutor.plugin.v0": [
+        "tutor.plugin.v1": [
             "openstack = tutoropenstack.plugin"
         ]
     },


### PR DESCRIPTION
Tutor v1 plugin API was introduces in Tutor 13.2.0. Refactor the plugin
to use the v1 API instead of the legacy v0 API.

Reference: https://github.com/overhangio/cookiecutter-tutor-plugin#migrating-from-v0-plugins