### PR TITLE
feat: Add the ability to set a keypair for the cluster template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* feat: Add the ability to set an SSH keypair on the cluster
+  *template,* as opposed to just the cluster.
+
 ## Version 0.2.0 (2022-06-29)
 
 * refactor: Use Tutor v1 plugin API.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ to any invocation of the `tutor openstack create-cluster` command.
 Other variables can only be set for a *cluster template,* and will
 thus apply only if you run `tutor openstack create-template`:
 
+* `OPENSTACK_TEMPLATE_KEYPAIR`: The default keypair to configure with
+  your template. If unset, no keypair reference will be set on the
+  template, and you would set the keypair with
+  `OPENSTACK_KEYPAIR`.
 * `OPENSTACK_KUBERNETES_VERSION`: The Kubernetes version to deploy. If
   unset, this will configure the template to deploy whatever
   Kubernetes release is the default for your version of OpenStack

--- a/tutoropenstack/command.py
+++ b/tutoropenstack/command.py
@@ -110,6 +110,7 @@ def create_coe_cluster_template_kwargs(config):
     image = config['OPENSTACK_IMAGE']
     hyperkube_prefix = config['OPENSTACK_HYPERKUBE_PREFIX']
     enable_registry = config['OPENSTACK_ENABLE_REGISTRY']
+    keypair = config['OPENSTACK_TEMPLATE_KEYPAIR']
 
     labels = {
         'container_runtime': 'containerd',
@@ -145,6 +146,8 @@ def create_coe_cluster_template_kwargs(config):
     if enable_registry:
         kwargs['registry_enabled'] = True
         kwargs['insecure_registry'] = 'localhost:5000'
+    if keypair:
+        kwargs['keypair'] = keypair
     return kwargs
 
 

--- a/tutoropenstack/plugin.py
+++ b/tutoropenstack/plugin.py
@@ -13,6 +13,7 @@ config = {
     "defaults": {
         'CLUSTER_NAME': 'tutor',
         'TEMPLATE': 'tutor-kubernetes',
+        'TEMPLATE_KEYPAIR': None,
         'KEYPAIR': None,
         'MASTER_COUNT': 1,
         'NODE_COUNT': 1,


### PR DESCRIPTION
Sometimes it's helpful to be able to set the keypair at the template rather than at the cluster level. That way, a new keypair can be rolled out via a cluster update (which references a new template).