### PR TITLE
fix: When creating a cluster template, use keypair_id, not keypair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* fix: When invoking the OpenStack Magnum API for template creation,
+  identify the keypair with `keypair_id`, not just `keypair`.
+
 ## Version 0.3.0 (2022-07-20)
 
 * feat: Add the ability to set an SSH keypair on the cluster

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "tutor <14, >=13.2.0",
         "openstacksdk",
     ],
-    setup_requires=['setuptools-scm'],
+    setup_requires=['setuptools-scm<7'],
     entry_points={
         "tutor.plugin.v1": [
             "openstack = tutoropenstack.plugin"

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ envlist = gitlint,py{36,37,38,39,310},flake8
 
 [gh-actions]
 python =
-    '3.6': gitlint,py36,flake8
-    '3.7': gitlint,py37,flake8
-    '3.8': gitlint,py38,flake8
-    '3.9': gitlint,py39,flake8
-    '3.10': gitlint,py310,flake8
+    3.6: gitlint,py36,flake8
+    3.7: gitlint,py37,flake8
+    3.8: gitlint,py38,flake8
+    3.9: gitlint,py39,flake8
+    3.10: gitlint,py310,flake8
 
 [flake8]
 ignore = E124,W504

--- a/tutoropenstack/command.py
+++ b/tutoropenstack/command.py
@@ -147,7 +147,7 @@ def create_coe_cluster_template_kwargs(config):
         kwargs['registry_enabled'] = True
         kwargs['insecure_registry'] = 'localhost:5000'
     if keypair:
-        kwargs['keypair'] = keypair
+        kwargs['keypair_id'] = keypair
     return kwargs
 
 


### PR DESCRIPTION
The API call for creating a cluster template requires the keypair to be referenced by the parameter `keypair_id`, not `keypair`.

Update the call accordingly.

Also, fix the tox and CI definitions to that the tests are actually run by GitHub Actions.