### PR TITLE
build: Version 1.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 commit = True
 tag = True
 message = build: Version {new_version}
-current_version = 0.3.1
+current_version = 1.0.0
 
 [bumpversion:file:CHANGELOG.md]
 search = Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## Version 1.0.0 (2022-08-04)
 
 * [BREAKING CHANGE] Support Tutor 14 and Open edX Nutmeg. This entails
   a configuration format change from JSON to YAML, meaning that from

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ appropriate one:
 ## Installation
 
 ```
-pip install git+https://github.com/hastexo/tutor-contrib-openstack@v0.3.1
+pip install git+https://github.com/hastexo/tutor-contrib-openstack@v1.0.0
 ```
 
 


### PR DESCRIPTION
As of this release, the plugin supports Tutor v14 and hence Open edX Nutmeg.