### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,8 +10,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.6'
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,9 +16,13 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
+      with:
+        # Checkout a pull request's HEAD commit instead of the merge
+        # commit, so that gitlint lints the correct commit message.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,6 @@
 [general]
 contrib=contrib-title-conventional-commits
+regex-style-search=true
 
 # When invoked as just "gitlint" without any other arguments, Gitlint
 # processes the most recent commit message *unless* it's being fed

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,6 @@ envlist = gitlint,py{36,37,38,39,310},flake8
 
 [gh-actions]
 python =
-    3.6: gitlint,py36,flake8
-    3.7: gitlint,py37,flake8
     3.8: gitlint,py38,flake8
     3.9: gitlint,py39,flake8
     3.10: gitlint,py310,flake8


### PR DESCRIPTION
* Lint the correct commit from GitHub Actions
* Silence a `gitlint` warning
* Drop Python 3.6 and 3.7 from the test matrix (they were never really needed, anyway)