### PR TITLE
build: Fix the tox.ini "envlist" entry

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = gitlint,py{36,37,38,39,310},flake8
+envlist = gitlint,py{38,39,310},flake8
 
 [gh-actions]
 python =


### PR DESCRIPTION
In 8051f7ed4e9983ce50f722dfd122436813340805 I neglected to drop `py36` and `py37` from the tox `envlist`. This has no bearing on the GitHub Actions workflow nor the pre-commit or pre-push hooks but it breaks locally running just `tox` (without an `-e` option).

Drop the non-existing testenvs from the list.