### PR TITLE
feat: Add ability to set a boot volume size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* fix: Add the ability to set a boot volume size when creating the
+  cluster template (via `OPENSTACK_BOOT_VOLUME_SIZE`).
+
 ## Version 1.3.1 (2024-01-16)
 
 * fix: Make the `tutor openstack registry` command behave correctly

--- a/tutoropenstack/command.py
+++ b/tutoropenstack/command.py
@@ -102,6 +102,7 @@ def create_coe_cluster_template_kwargs(config):
     """Construct arguments for the create_coe_cluster_template command."""
     kubernetes_version = config['OPENSTACK_KUBERNETES_VERSION']
     name = config['OPENSTACK_TEMPLATE']
+    boot_volume_size = config['OPENSTACK_BOOT_VOLUME_SIZE']
     docker_volume_size = config['OPENSTACK_DOCKER_VOLUME_SIZE']
     external_network = config['OPENSTACK_EXTERNAL_NETWORK']
     master_flavor = config['OPENSTACK_MASTER_FLAVOR']
@@ -124,6 +125,8 @@ def create_coe_cluster_template_kwargs(config):
         labels['kube_tag'] = f'v{kubernetes_version}'
     if hyperkube_prefix:
         labels['hyperkube_prefix'] = hyperkube_prefix
+    if boot_volume_size:
+        labels['boot_volume_size'] = boot_volume_size
 
     kwargs = {
         'name': name,

--- a/tutoropenstack/plugin.py
+++ b/tutoropenstack/plugin.py
@@ -19,6 +19,7 @@ config = {
         'NODE_COUNT': 1,
         'KUBERNETES_VERSION': None,
         'DOCKER_VOLUME_SIZE': 50,
+        'BOOT_VOLUME_SIZE': None,
         'FIXED_NETWORK': None,
         'FIXED_SUBNET': None,
         'NETWORK_DRIVER': None,


### PR DESCRIPTION
The OpenStack Magnum cluster may be configured with boot-from-volume
flavors. In that case, we need to be able to specify the boot volume
size, via an additional cluster template label.

Support an additional (optional) configuration option,
OPENSTACK_BOOT_VOLUME_SIZE, so we can set the boot volume size.
