### PR TITLE
feat: Support Python 3.12

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,6 +14,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
 
     steps:
     - name: Check out code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* feat: Support Python 3.12.
+
 ## Version 1.3.2 (2024-01-22)
 
 * fix: Un-break cluster template creation with `openstacksdk>=1.0.0`.

--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,10 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = gitlint,py{38,39,310,311},flake8
+envlist = gitlint,py{38,39,310,311,312},flake8
 
 [gh-actions]
 python =
@@ -7,6 +7,7 @@ python =
     3.9: gitlint,py39,flake8
     3.10: gitlint,py310,flake8
     3.11: gitlint,py311,flake8
+    3.12: gitlint,py312,flake8
 
 [flake8]
 ignore = E124,W504

--- a/tutoropenstack/__about__.py
+++ b/tutoropenstack/__about__.py
@@ -8,6 +8,5 @@ options) by:
 https://packaging.python.org/guides/single-sourcing-package-version/
 """
 
-import pkg_resources
-__version__ = pkg_resources.get_distribution(
-    'tutor-contrib-openstack').version
+from importlib import metadata
+__version__ = metadata.version('tutor-contrib-openstack')


### PR DESCRIPTION
* Replace the use of `pkg_resources` (from `setuptools`, which is no longer included in virtual environments as of 3.12) with `importlib.metadata`.
* Add Python 3.12 to the test matrix.
* Update the Trove classifiers in `setup.py`: drop support for Python 3.6 and 3.7, add support for Python 3.12.

