### PR TITLE
fix: Support cluster template creation post openstacksdk 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* fix: Un-break cluster template creation with `openstacksdk>=1.0.0`.
 * fix: Add the ability to set a boot volume size when creating the
   cluster template (via `OPENSTACK_BOOT_VOLUME_SIZE`).
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "tutor <18, >=14.0.0",
-        "openstacksdk",
+        "openstacksdk>=1.0.0",
     ],
     setup_requires=['setuptools-scm<7'],
     entry_points={

--- a/tutoropenstack/command.py
+++ b/tutoropenstack/command.py
@@ -185,7 +185,7 @@ def create_template(context, dry_run):
         fmt.echo_info("Dry run, not invoking API call")
     else:
         conn = get_openstack_connection()
-        cluster = conn.create_coe_cluster_template(**kwargs)
+        cluster = conn.create_cluster_template(**kwargs)
         fmt.echo_info("Cluster template creation returned:\n%s" %
                       pformat(cluster))
 


### PR DESCRIPTION
Prior to release 1.0.0 of `openstacksdk`, the `Connection` object's `create_coe_cluster_template()` method was a valid alias for `create_cluster_template()`, but in the commit referenced below, this alias was dropped.

Thus, use the unaliased method to un-break cluster template creation.

Also, since nobody should be using pre-1.0.0 versions of `openstacksdk` anymore, include that version requirement in the `setup.py` `install_requires` list.

Reference:
https://opendev.org/openstack/openstacksdk/commit/b66c6cc847bc0bfd9ffdbc25bfb74a0bf568d6e3