### PR TITLE
feat: Add support for Tutor 18 / Open edX Redwood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Support Tutor 18 and Open edX Redwood.
+
 ## Version 1.4.0 (2024-04-05)
 
 * [Enhancement] Support Python 3.12.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ appropriate one:
 | Olive            | `>=15.0, <16`     | `main`        | 1.x.x          |
 | Palm             | `>=16.0, <17`     | `main`        | 1.x.x          |
 | Quince           | `>=17.0, <18`     | `main`        | 1.x.x          |
+| Redwood          | `>=18.0, <19`     | `main`        | 1.x.x          |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
     later. That is because this plugin uses the Tutor v1 plugin API,

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     include_package_data=True,
     python_requires=">=3.6",
     install_requires=[
-        "tutor <18, >=14.0.0",
+        "tutor <19, >=14.0.0",
         "openstacksdk>=1.0.0",
     ],
     setup_requires=['setuptools-scm<7'],


### PR DESCRIPTION
* Update the install_requires list to support Tutor 18.
* Update the compatibility matrix in the README accordingly.