### PR TITLE
chore: Drop support for Python 3.8

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* chore: Drop Python 3.8 support.
+
 ## Version 1.5.0 (2024-07-31)
 
 * [Enhancement] Support Tutor 18 and Open edX Redwood.

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ appropriate one:
 |------------------|-------------------|---------------|----------------|
 | Lilac            | `>=12.0, <13`     | Not supported | Not supported  |
 | Maple            | `>=13.2, <14`[^1] | `maple`       | 0.3.x          |
-| Nutmeg           | `>=14.0, <15`     | `main`        | 1.x.x          |
-| Olive            | `>=15.0, <16`     | `main`        | 1.x.x          |
-| Palm             | `>=16.0, <17`     | `main`        | 1.x.x          |
-| Quince           | `>=17.0, <18`     | `main`        | 1.x.x          |
-| Redwood          | `>=18.0, <19`     | `main`        | 1.x.x          |
+| Nutmeg           | `>=14.0, <15`     | `quince`      | `>=1.0.0, <2`  |
+| Olive            | `>=15.0, <16`     | `quince`      | `>=1.1.0, <2`  |
+| Palm             | `>=16.0, <17`     | `quince`      | `>=1.2.0, <2`  |
+| Quince           | `>=17.0, <18`     | `quince`      | `>=1.3.0, <2`  |
+| Redwood          | `>=18.0, <19`     | `main`        | `>=2`          |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
     later. That is because this plugin uses the Tutor v1 plugin API,

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     long_description_content_type='text/markdown',
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     install_requires=[
         "tutor <19, >=14.0.0",
         "openstacksdk>=1.0.0",
@@ -44,9 +44,6 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = gitlint,py{38,39,310,311,312},flake8
+envlist = gitlint,py{39,310,311,312},flake8
 
 [gh-actions]
 python =
-    3.8: gitlint,py38,flake8
     3.9: gitlint,py39,flake8
     3.10: gitlint,py310,flake8
     3.11: gitlint,py311,flake8


### PR DESCRIPTION
Python 3.8 will end security support on 2024-10-31; drop support for Python 3.8 in this plugin.