### PR TITLE
feat: Add the ability to override the registry and/or registry-ui image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Add the ability to override the registry and registry-ui images (with the `OPENSTACK_REGISTRY_IMAGE` and `OPENSTACK_REGISTRY_UI_IMAGE` options).
+
 ## Version 2.1.0 (2024-10-15)
 
 * [Enhancement] Add the ability to run the registry in read-only mode: `tutor openstack registry --read-only`.

--- a/tutoropenstack/command.py
+++ b/tutoropenstack/command.py
@@ -309,7 +309,7 @@ def registry(context, with_ui, read_only):
             "--network", "host",
             "-v", "%s:/etc/docker/registry/config.yml" % config_file.name,
             "--name", "tutor-openstack-registry",
-            "registry:2"
+            config['OPENSTACK_REGISTRY_IMAGE'],
         ]
 
         docker_run(*registry_args)
@@ -362,7 +362,7 @@ def registry(context, with_ui, read_only):
             "-e", f"REGISTRY_TITLE={registry_title}",
             "-e", "DELETE_IMAGES=true",
             "--name", "tutor-openstack-registry-ui",
-            "joxit/docker-registry-ui:2"
+            config['OPENSTACK_REGISTRY_UI_IMAGE'],
         ]
         docker_run(*registry_ui_args)
         fmt.echo_info(f"Registry web UI for {registry_title} "

--- a/tutoropenstack/plugin.py
+++ b/tutoropenstack/plugin.py
@@ -28,6 +28,8 @@ config = {
         'NETWORK_DRIVER': None,
         'HYPERKUBE_PREFIX': None,
         'ENABLE_REGISTRY': False,
+        'REGISTRY_IMAGE': 'registry:2',
+        'REGISTRY_UI_IMAGE': 'joxit/docker-registry-ui:2',
     },
 }
 


### PR DESCRIPTION
In case one uses a local registry that can cache the registry and
registry-ui images, that may be preferable over always pulling from
docker.io.

Define two new options, OPENSTACK_REGISTRY_IMAGE and
OPENSTACK_REGISTRY_UI_IMAGE, to allow that.
