### PR TITLE
docs: Update README and CHANGELOG to mention repo move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Point release to mark the GitHub repository move.
+
 ## Version 2.1.0 (2024-10-15)
 
 * [Enhancement] Add the ability to run the registry in read-only mode: `tutor openstack registry --read-only`.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This plugin (indirectly) relies on the availability of the Swift backend driver 
 
 As such, we have no plans to support this plugin beyond the Tutor 18/Open edX "Redwood" release, and encourage users to switch to a registry other than the built-in private registry that comes with OpenStack Magnum.
 
+This repository was previously hosted under the `hastexo` GitHub organization, and moved to `cleura` in December 2025 as part of a routine repository consolidation.
+
 * * *
 
 This **experimental** plugin adds a `tutor openstack` command group to
@@ -50,7 +52,7 @@ appropriate one:
 ## Installation
 
 ```
-pip install git+https://github.com/hastexo/tutor-contrib-openstack@v2.1.0
+pip install git+https://github.com/cleura/tutor-contrib-openstack@v2.1.0
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,10 @@ def load_readme():
 setup(
     name="tutor-contrib-openstack",
     use_scm_version=True,
-    url="https://github.com/hastexo/tutor-contrib-openstack",
+    url="https://github.com/cleura/tutor-contrib-openstack",
     project_urls={
-        "Code": "https://github.com/hastexo/tutor-contrib-openstack",
-        "Issue tracker": "https://github.com/hastexo/tutor-contrib-openstack/issues",  # noqa: E501
+        "Code": "https://github.com/cleura/tutor-contrib-openstack",
+        "Issue tracker": "https://github.com/cleura/tutor-contrib-openstack/issues",  # noqa: E501
     },
     license="AGPLv3",
     author="Florian Haas",


### PR DESCRIPTION
Mention that the repo has been moved from the hastexo to the cleura org.